### PR TITLE
warm up execution cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ RUN ln -s /exercises-csharp/src /src
 
 COPY . .
 
+RUN make test


### PR DESCRIPTION
Еще одна отчаянная попытка ускорить стартап скриптов.

`dotnet-script` компилирует файлы перед выполнением. Скомпиленные скрипты хранятся во временной директории ([execution cache](https://github.com/filipw/dotnet-script#execution-cache)). Можно попробовать на этапе создания образа заполнять этот кеш скомпиленными бинарями.

Понятно что в рантайме это исходные коды будут подмениваться на то, что напишут студенты. Но некоторый выигрыш это должно дать.


