### PR TITLE
fix int convertion error

### DIFF
--- a/modules/50-data-types/50-type-casting/description.ru.yml
+++ b/modules/50-data-types/50-type-casting/description.ru.yml
@@ -6,7 +6,7 @@ theory: |
 
   ```cs
   // станет int
-  var number = int.parse("345");
+  var number = Convert.ToInt32("345");
   Console.WriteLine(number); // => 345
   ```
 

--- a/modules/60-methods-using/60-methods-deterministic/Test.csx
+++ b/modules/60-methods-using/60-methods-deterministic/Test.csx
@@ -5,7 +5,7 @@
 using PowerAssert;
 
 var output = capturedConsoleOutput.ToString().Trim();
-var outputAsNumber = int.Parse(output);
+var outputAsNumber = Convert.ToInt32(output);
 Console.SetOut(originalStdOut);
 
 PAssert.IsTrue(() => outputAsNumber >= 0 && outputAsNumber < 10);


### PR DESCRIPTION
По какой-то причине `int.Parse` не работает в моно