### PR TITLE
fix solution

### DIFF
--- a/modules/95-loops/20-aggregation-strings/Exercise.csx
+++ b/modules/95-loops/20-aggregation-strings/Exercise.csx
@@ -8,7 +8,7 @@ class App
 
         while (i <= finish)
         {
-            result = result + i;
+            result = result + i.ToString();
             i = i + 1;
         }
 


### PR DESCRIPTION
In lesson we talk about string concatenation and advice using .ToString() method. But in current solution we use `+` operator to concatenate string representation which is different from the explicit string conversion.